### PR TITLE
Add select-all checkbox for personal files toolbar

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -236,15 +236,52 @@ const checkboxes = document.querySelectorAll('.file-checkbox');
 const deleteSelectedBtn = document.getElementById('deleteSelectedBtn');
 const shareSelectedBtn = document.getElementById('shareSelectedBtn');
 const backupSelectedBtn = document.getElementById('backupSelectedBtn');
+const selectAllCheckbox = document.getElementById('selectAllFiles');
+
+function updateSelectionUI() {
+    const totalCheckboxes = checkboxes.length;
+    const checkedCount = document.querySelectorAll('.file-checkbox:checked').length;
+
+    if (deleteSelectedBtn) {
+        deleteSelectedBtn.style.display = checkedCount > 0 ? 'inline-block' : 'none';
+    }
+    if (shareSelectedBtn) {
+        shareSelectedBtn.style.display = checkedCount > 0 ? 'inline-block' : 'none';
+    }
+    if (backupSelectedBtn) {
+        backupSelectedBtn.style.display = checkedCount > 0 ? 'inline-block' : 'none';
+    }
+
+    if (selectAllCheckbox) {
+        selectAllCheckbox.disabled = totalCheckboxes === 0;
+        if (totalCheckboxes === 0) {
+            selectAllCheckbox.indeterminate = false;
+            selectAllCheckbox.checked = false;
+            return;
+        }
+
+        selectAllCheckbox.indeterminate = checkedCount > 0 && checkedCount < totalCheckboxes;
+        selectAllCheckbox.checked = checkedCount === totalCheckboxes;
+    }
+}
 
 checkboxes.forEach(checkbox => {
     checkbox.addEventListener('change', () => {
-        const checkedCount = document.querySelectorAll('.file-checkbox:checked').length;
-        deleteSelectedBtn.style.display = checkedCount > 0 ? 'inline-block' : 'none';
-        shareSelectedBtn.style.display = checkedCount > 0 ? 'inline-block' : 'none';
-        backupSelectedBtn.style.display = checkedCount > 0 ? 'inline-block' : 'none';
+        updateSelectionUI();
     });
 });
+
+if (selectAllCheckbox) {
+    selectAllCheckbox.addEventListener('change', () => {
+        const shouldCheckAll = selectAllCheckbox.checked;
+        checkboxes.forEach(checkbox => {
+            checkbox.checked = shouldCheckAll;
+        });
+        updateSelectionUI();
+    });
+}
+
+updateSelectionUI();
 
 deleteSelectedBtn.addEventListener('click', () => {
     const selectedIds = Array.from(document.querySelectorAll('.file-checkbox:checked')).map(cb => cb.value);

--- a/dashboard.php
+++ b/dashboard.php
@@ -295,6 +295,10 @@ function get_existing_public_link($conn, $file_id) {
                     <div class="search-container">
                         <input type="text" id="searchInput" class="form-control search-input" placeholder="Cari file..." autocomplete="off">
                     </div>
+                    <div class="form-check mb-3">
+                        <input class="form-check-input" type="checkbox" id="selectAllFiles">
+                        <label class="form-check-label" for="selectAllFiles">Pilih Semua</label>
+                    </div>
                     <button id="backupSelectedBtn" class="btn btn-gradient me-2" style="display: none;"><i class="fas fa-download me-2"></i> Backup</button>
                     <button id="shareSelectedBtn" class="btn btn-gradient me-2" style="display: none;"><i class="fas fa-share-alt me-2"></i> Bagikan Terpilih</button>
                     <button id="deleteSelectedBtn" class="btn btn-gradient" style="display: none;"><i class="fas fa-trash me-2"></i> Hapus Terpilih</button>


### PR DESCRIPTION
## Summary
- add a "Pilih Semua" checkbox to the personal files toolbar for quicker bulk selection
- synchronize the new master checkbox with individual file selections and bulk action visibility

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ce485ab97c832d9e994b705cfef87f